### PR TITLE
Fix URI query-form

### DIFF
--- a/lib/Twitter/OAuth.pm6
+++ b/lib/Twitter/OAuth.pm6
@@ -26,7 +26,7 @@ method !sign (
     my $nonce     = $*TEST-TWITTER-OAUTH-NONCE // (rand ~ $*PID ~ rand);
 
     my %params =
-        URI.new("?$body").query-form,
+        URI.new("?$body").query-form.Hash,
         oauth_version           => '1.0',
         oauth_consumer_key	    => $!consumer-key,
         oauth_nonce	            => $nonce,


### PR DESCRIPTION
[`query-form `](https://github.com/raku-community-modules/uri/blob/master/lib/URI.pm#L113) in URI is a Pair  and when doing this `%params = %params.kv.map: { uri-escape $_ };` it's passed as an item (Pair)
si `uri-escape` will fail with "No such method 'subst' for invocant of type 'Pair'"